### PR TITLE
Very minimal main function

### DIFF
--- a/src/bin/cymba.rs
+++ b/src/bin/cymba.rs
@@ -1,0 +1,28 @@
+extern crate cymbalum;
+use cymbalum::input::read_config;
+
+use std::env;
+use std::process::exit;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.contains(&"-h".into()) || args.contains(&"--help".into()) || args.len() != 2 {
+        return usage();
+    }
+
+    let input = &args[1];
+    let mut config = match read_config(input) {
+        Ok(config) => config,
+        Err(err) => {
+            println!("Error in input file: {}", err);
+            exit(2);
+        }
+    };
+
+    config.simulation.run(&mut config.system, config.nsteps);
+}
+
+fn usage() {
+    let name = env::args().next().unwrap_or("cymba".into());
+    println!("Usage: {} input.toml", name);
+}


### PR DESCRIPTION
This add a very minimal binary to cymbalum, using the recent input module to setup the run. 

The main function should be expanded with a real interface and better error messages, but this is a starting point, allowing people to run simulations without writing code! 