### PR TITLE
Refactor pairs interactions

### DIFF
--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -12,7 +12,7 @@
     - [Adsorption in zeolites]()
 
 
-- [Input files](input/intro.md)
+- [Input files reference](input/intro.md)
     - [Systems](input/systems.md)
     - [Interactions](input/interactions.md)
     - [Potentials](input/potentials.md)

--- a/doc/src/input/interactions.md
+++ b/doc/src/input/interactions.md
@@ -15,6 +15,9 @@ An example of an input file for the f-SPC model of water is given bellow:
 [input]
 version = 1
 
+[global]
+cutoff = "12.5 A"
+
 [[pairs]]
 atoms = ["O", "O"]
 lj = {sigma = "3.16 A", epsilon = "0.155 kcal/mol"}
@@ -61,10 +64,17 @@ atoms = ["C", "H"]
 harmonic = {x0 = "3.405 A", k = "2385 kcal/mol/A^2"}
 ```
 
-It is also possible in the `pairs` section to specify an additional
-[restriction](input/potentials.html#Restrictions) using the `restriction` key;
-or a [computation method](input/potentials.html#Potential%20computations) using
-the `computation` key.
+Within the `pairs` section, additional information about how to compute the
+pair potential can be given:
+
+- A [restriction](input/potentials.html#Restrictions) restrict the potential
+  to a subset of the pairs in the system with the `restriction` keyword;
+- A different [computation method](   
+  input/potentials.html#Potential%20computations) can be specified with the
+  `computation` keyword;
+- A different [cutoff treatment](
+  input/interactions.html#Cutoff%20treatment%20for%20pair%20interactions) is
+  specified by the `cutoff` keyword.
 
 ```toml
 [[pairs]]
@@ -74,13 +84,59 @@ computation = {table = {n = 2000, max = "20.0 A"}}
 restriction  = "IntraMolecular"
 ```
 
+### Cutoff treatment for pair interactions
+
+Two different cutoff treatments are available for pair interactions: a simple
+cutoff distance, or a shifted potential with a cutoff. With a simple cutoff the
+potential is only set to zero after the cutoff distance. With a shifted
+potential, the potential energy is shifted so that it is zero at the cutoff
+distance and after. This mean that the energy is continuous for the shifted
+potential, which is a desirable property for molecular dynamics stability.
+
+In the input files, a simple cutoff can be used with `cutoff = "8 A"`, and a
+shifted potential can be used with `cutoff = {shifted = "8 A"}`. The cutoff treatment can be set either globally in the `[global]` table:
+
+```toml
+[input]
+version = 1
+
+[global]
+cutoff = "8 A"
+
+[[pairs]]
+# ...
+# All pairs interaction will use a 8 A cutoff, unless specified otherwise.
+```
+
+or specifically for each pair interaction:
+
+```toml
+[input]
+version = 1
+
+[[pairs]]
+cutoff = "8 A"
+# ...
+
+[[pairs]]
+cutoff = {shifted: "7 A"}
+# ...
+
+[[pairs]]
+cutoff = "12 A"
+# ...
+```
+
+If a global cutoff is defined, defining another cutoff in a `pairs` section
+will override the global cutoff.
+
 ## Coulombic interactions
 
 The method for treatment of electrostatic interactions is specified in the
 `coulomb` section. There are multiple available solvers for [electrostatic
 interactions](input/potentials.html#Electrostatic%20interactions). Optionally,
-an additional [restriction](input/potentials.html#Restrictions) can be specified
-with the `restriction` key.
+an additional [restriction](input/potentials.html#Restrictions) can be
+specified with the `restriction` key.
 
 ```toml
 [coulomb]

--- a/doc/src/input/intro.md
+++ b/doc/src/input/intro.md
@@ -1,4 +1,4 @@
-# Input files
+# Input files syntax reference
 
 Cymbalum input files uses the [TOML][TOML] format, a simple and minimalist
 configuration format based on `key = value` pairs. You can read an introduction

--- a/doc/src/input/potentials.md
+++ b/doc/src/input/potentials.md
@@ -209,33 +209,11 @@ is to use the mathematical function corresponding to a potential to compute it.
 To use another computation, the `computation` keyword can be used in the
 `[[pairs]]` section.
 
-## Cutoff computation
-
-It is possible to use a cutoff radius $rc$ to compute a potential $U(r)$ such
-that:
-
-$$ V(r) = \begin{cases}
-    U(r) - U(rc) & r <= rc \\\\
-    0 & r > rc
-\end{cases}$$
-
-The potential $U$ is additionally shifted to make sure it is continuous at $r =
-rc$. This is important for molecular dynamics, where a discontinuity means an
-infinite force in the integration.
-
-You can choose the `cutoff` by providing it in the input:
-```toml
-[[pairs]]
-atoms = ["O", "O"]
-lj = {sigma = "3 A", epsilon = "123 kJ/mol"}
-computation = {cutoff = "8 A"}
-```
-
 ## Table interpolation
 
-Another way to compute a potential is to pre-compute it on a regularly spaced
-grid, and then to interpolate values for points in the grid. In some cases, this
-can be faster than recomputing the function every time.
+A way to compute a potential is to pre-compute it on a regularly spaced grid,
+and then to interpolate values for points in the grid. In some cases, this can
+be faster than recomputing the function every time.
 
 This can be done with the `table` computation, which does a linear interpolation
 in regularly spaced values in the `[0, max)` segment. You need to provide the

--- a/examples/argon.rs
+++ b/examples/argon.rs
@@ -23,11 +23,13 @@ fn main() {
             }
         }
     }
+
+    let lj = Box::new(LennardJones {
+        sigma: units::from(3.4, "A").unwrap(),
+        epsilon: units::from(1.0, "kJ/mol").unwrap()
+    });
     system.interactions_mut().add_pair("Ar", "Ar",
-        Box::new(LennardJones {
-            sigma: units::from(3.4, "A").unwrap(),
-            epsilon: units::from(1.0, "kJ/mol").unwrap()
-        })
+        PairInteraction::new(lj, units::from(8.5, "A").unwrap())
     );
 
     let mut velocities = BoltzmannVelocities::new(units::from(300.0, "K").unwrap());

--- a/examples/custom-potential.rs
+++ b/examples/custom-potential.rs
@@ -41,12 +41,11 @@ fn main() {
     system[1].position = Vector3D::new(1.5, 0.0, 0.0);
 
     // We can now use our new potential in the system
-    system.interactions_mut().add_pair("F", "F",
-        Box::new(LJ {
-            a: units::from(675.5, "kJ/mol/A^12").unwrap(),
-            b: units::from(40.26, "kJ/mol/A^6").unwrap()
-        }
-    ));
+    let lj = Box::new(LJ {
+        a: units::from(675.5, "kJ/mol/A^12").unwrap(),
+        b: units::from(40.26, "kJ/mol/A^6").unwrap()
+    });
+    system.interactions_mut().add_pair("F", "F", PairInteraction::new(lj, 10.0));
 
     let mut simulation = Simulation::new(Box::new(
         MolecularDynamics::new(units::from(1.0, "fs").unwrap())

--- a/examples/custom-potential.rs
+++ b/examples/custom-potential.rs
@@ -15,8 +15,8 @@ struct LJ {
     b: f64
 }
 
-/// All we need to do is to implement the PotentialFunction trait
-impl PotentialFunction for LJ {
+/// All we need to do is to implement the Potential trait
+impl Potential for LJ {
     /// The energy function give the energy at distance `r`
     fn energy(&self, r: f64) -> f64 {
         self.a / r.powi(12) - self.b / r.powi(6)

--- a/examples/minimization.rs
+++ b/examples/minimization.rs
@@ -20,9 +20,10 @@ fn main() {
 
     {
         let interactions = system.interactions_mut();
-        interactions.add_pair("O", "H", Box::new(NullPotential));
-        interactions.add_pair("O", "O", Box::new(NullPotential));
-        interactions.add_pair("H", "H", Box::new(NullPotential));
+        let null_interaction = PairInteraction::new(Box::new(NullPotential), 10.0);
+        interactions.add_pair("O", "H", null_interaction.clone());
+        interactions.add_pair("O", "O", null_interaction.clone());
+        interactions.add_pair("H", "H", null_interaction.clone());
 
         interactions.add_bond("O", "H", Box::new(Harmonic{
             x0: units::from(1.1, "A").unwrap(),

--- a/examples/xenon.rs
+++ b/examples/xenon.rs
@@ -9,12 +9,11 @@ fn main() {
     let mut system = trajectory.read().unwrap();
     system.set_cell(UnitCell::cubic(units::from(21.65, "A").unwrap()));
 
-    system.interactions_mut().add_pair("Xe", "Xe",
-        Box::new(LennardJones{
-            sigma: units::from(4.57, "A").unwrap(),
-            epsilon: units::from(1.87, "kJ/mol").unwrap()
-        }
-    ));
+    let lj = Box::new(LennardJones{
+        sigma: units::from(4.57, "A").unwrap(),
+        epsilon: units::from(1.87, "kJ/mol").unwrap()
+    });
+    system.interactions_mut().add_pair("Xe", "Xe", PairInteraction::new(lj, 12.0));
 
     // Create a Monte-Carlo propagator
     let mut mc = MonteCarlo::new(units::from(500.0, "K").unwrap());

--- a/src/input/interactions/data/bad/pairs/pairs-10.toml
+++ b/src/input/interactions/data/bad/pairs/pairs-10.toml
@@ -1,0 +1,10 @@
+[input]
+version = 1
+
+[global]
+# cutoff.shifted value is not a string
+cutoff = {shifted = 6}
+
+[[pairs]]
+atoms = ["A", "A"]
+lj = {sigma = "3 A", epsilon = "5.9 kJ/mol"}

--- a/src/input/interactions/data/bad/pairs/pairs-6.toml
+++ b/src/input/interactions/data/bad/pairs/pairs-6.toml
@@ -1,0 +1,7 @@
+[input]
+version = 1
+
+[[pairs]]
+atoms = ["A", "A"]
+# No cutoff value
+lj = {sigma = "3 A", epsilon = "5.9 kJ/mol"}

--- a/src/input/interactions/data/bad/pairs/pairs-7.toml
+++ b/src/input/interactions/data/bad/pairs/pairs-7.toml
@@ -1,0 +1,8 @@
+[input]
+version = 1
+
+[[pairs]]
+atoms = ["A", "A"]
+# cutoff value is not a string
+cutoff = 5
+lj = {sigma = "3 A", epsilon = "5.9 kJ/mol"}

--- a/src/input/interactions/data/bad/pairs/pairs-8.toml
+++ b/src/input/interactions/data/bad/pairs/pairs-8.toml
@@ -1,0 +1,10 @@
+[input]
+version = 1
+
+[global]
+# cutoff value is not a string
+cutoff = 2
+
+[[pairs]]
+atoms = ["A", "A"]
+lj = {sigma = "3 A", epsilon = "5.9 kJ/mol"}

--- a/src/input/interactions/data/bad/pairs/pairs-9.toml
+++ b/src/input/interactions/data/bad/pairs/pairs-9.toml
@@ -1,0 +1,10 @@
+[input]
+version = 1
+
+[global]
+# cutoff table does not contains 'shifted'
+cutoff = {foo = 6}
+
+[[pairs]]
+atoms = ["A", "A"]
+lj = {sigma = "3 A", epsilon = "5.9 kJ/mol"}

--- a/src/input/interactions/data/pairs.toml
+++ b/src/input/interactions/data/pairs.toml
@@ -10,12 +10,6 @@ atoms = ["A", "B"]
 harmonic = {x0 = "3 A", k = "5.9 kJ/mol/A^2"}
 
 [[pairs]]
-# Cutoff computations
-atoms = ["A", "B"]
-null = {}
-computation = {cutoff = "8 A"}
-
-[[pairs]]
 # Table computations
 atoms = ["A", "B"]
 null = {}

--- a/src/input/interactions/data/pairs.toml
+++ b/src/input/interactions/data/pairs.toml
@@ -59,3 +59,9 @@ restriction = {scale14 = 0.8}
 atoms = ["A", "B"]
 harmonic = {x0 = "3 A", k = "5.9 kJ/mol/A^2"}
 cutoff = "18 A"
+
+[[pairs]]
+# Shifted cutoff treatment
+atoms = ["A", "B"]
+harmonic = {x0 = "3 A", k = "5.9 kJ/mol/A^2"}
+cutoff = {shifted = "18 A"}

--- a/src/input/interactions/data/pairs.toml
+++ b/src/input/interactions/data/pairs.toml
@@ -1,6 +1,9 @@
 [input]
 version = 1
 
+[global]
+cutoff = "3 A"
+
 [[pairs]]
 atoms = ["A", "B"]
 lj = {sigma = "3 A", epsilon = "5.9 kJ/mol"}
@@ -50,3 +53,9 @@ restriction = "exclude14"
 atoms = ["A", "B"]
 null = {}
 restriction = {scale14 = 0.8}
+
+[[pairs]]
+# Cutoff
+atoms = ["A", "B"]
+harmonic = {x0 = "3 A", k = "5.9 kJ/mol/A^2"}
+cutoff = "18 A"

--- a/src/input/interactions/mod.rs
+++ b/src/input/interactions/mod.rs
@@ -8,7 +8,6 @@ use std::path::Path;
 
 use system::System;
 use potentials::{PairPotential, PairRestriction};
-use units;
 
 use input::{Error, Result};
 use input::validate;
@@ -68,15 +67,7 @@ pub fn read_interactions_toml(system: &mut System, config: &Table) -> Result<()>
             let global = try!(global.as_table().ok_or(Error::from(
                 "'global' section must be a table"
             )));
-            match global.get("cutoff") {
-                None => None,
-                Some(toml) => {
-                    let cutoff = try!(toml.as_str().ok_or(Error::from(
-                        "'global.cutoff' entry must be a string"
-                    )));
-                    Some(try!(units::from_str(cutoff)))
-                }
-            }
+            global.get("cutoff")
         } else {
             None
         };

--- a/src/input/interactions/mod.rs
+++ b/src/input/interactions/mod.rs
@@ -18,7 +18,7 @@ mod pairs;
 mod angles;
 mod coulomb;
 
-use self::pairs::{TwoBody, read_2body};
+use self::pairs::{read_pairs, read_bonds};
 use self::angles::{read_angles, read_dihedrals};
 use self::coulomb::{read_coulomb, set_charges};
 
@@ -62,14 +62,14 @@ pub fn read_interactions_toml(system: &mut System, config: &Table) -> Result<()>
         let pairs = try!(pairs.as_slice().ok_or(
             Error::from("The 'pairs' section must be an array")
         ));
-        try!(read_2body(system, pairs, TwoBody::Pairs));
+        try!(read_pairs(system, pairs));
     }
 
     if let Some(bonds) = config.get("bonds") {
         let bonds = try!(bonds.as_slice().ok_or(
             Error::from("The 'bonds' section must be an array")
         ));
-        try!(read_2body(system, bonds, TwoBody::Bonds));
+        try!(read_bonds(system, bonds));
     }
 
     if let Some(angles) = config.get("angles") {

--- a/src/input/interactions/pairs.rs
+++ b/src/input/interactions/pairs.rs
@@ -7,7 +7,7 @@ use input::error::{Error, Result};
 use input::FromToml;
 use super::{FromTomlWithPairs, read_restriction};
 
-use potentials::{PairPotential, BondPotential};
+use potentials::{PairPotential, PairInteraction, BondPotential};
 use potentials::{Harmonic, LennardJones, NullPotential};
 use potentials::{TableComputation, CutoffComputation};
 
@@ -42,12 +42,12 @@ pub fn read_pairs(system: &mut System, pairs: &[Value]) -> Result<()> {
             potential
         };
 
-        match try!(read_restriction(pair)) {
-            Some(restriction) => {
-                system.interactions_mut().add_pair_with_restriction(a, b, potential, restriction);
-            },
-            None => system.interactions_mut().add_pair(a, b, potential)
+        // TODO: get the real cutoff
+        let mut interaction = PairInteraction::new(potential, 10000.0);
+        if let Some(restriction) = try!(read_restriction(pair)) {
+            interaction.set_restriction(restriction);
         }
+        system.interactions_mut().add_pair(a, b, interaction);
     }
     Ok(())
 }

--- a/src/input/interactions/pairs.rs
+++ b/src/input/interactions/pairs.rs
@@ -7,18 +7,12 @@ use input::error::{Error, Result};
 use input::FromToml;
 use super::{FromTomlWithPairs, read_restriction};
 
-use potentials::PairPotential;
+use potentials::{PairPotential, BondPotential};
 use potentials::{Harmonic, LennardJones, NullPotential};
 use potentials::{TableComputation, CutoffComputation};
 
-pub enum TwoBody {
-    Pairs,
-    Bonds
-}
-
-/// Read either the "pairs" or the "bonds" section from the configuration. The
-/// `form` enum set where the interactions will be saved.
-pub fn read_2body(system: &mut System, pairs: &[Value], form: TwoBody) -> Result<()> {
+/// Read either the "pairs" section from the configuration.
+pub fn read_pairs(system: &mut System, pairs: &[Value]) -> Result<()> {
     for pair in pairs {
         let pair = try!(pair.as_table().ok_or(
             Error::from("Pair potential entry must be a table")
@@ -27,12 +21,16 @@ pub fn read_2body(system: &mut System, pairs: &[Value], form: TwoBody) -> Result
         let atoms = extract_slice!("atoms", pair as "pair potential");
         if atoms.len() != 2 {
             return Err(Error::from(
-                format!("Wrong size for 'atoms' section in pair potentials. Should be 2, is {}", atoms.len())
+                format!("Wrong size for 'atoms' section in pair potential. Should be 2, is {}", atoms.len())
             ));
         }
 
-        let a = try!(atoms[0].as_str().ok_or(Error::from("The first atom name is not a string in pair potential")));
-        let b = try!(atoms[1].as_str().ok_or(Error::from("The second atom name is not a string in pair potential")));
+        let a = try!(atoms[0].as_str().ok_or(Error::from(
+            "The first atom name is not a string in pair potential"
+        )));
+        let b = try!(atoms[1].as_str().ok_or(Error::from(
+            "The second atom name is not a string in pair potential"
+        )));
 
         let potential = try!(read_pair_potential(pair));
         let potential = if let Some(computation) = pair.get("computation") {
@@ -44,19 +42,35 @@ pub fn read_2body(system: &mut System, pairs: &[Value], form: TwoBody) -> Result
             potential
         };
 
-        match form {
-            TwoBody::Pairs => {
-                match try!(read_restriction(pair)) {
-                    Some(restriction) => {
-                        system.interactions_mut().add_pair_with_restriction(a, b, potential, restriction);
-                    },
-                    None => system.interactions_mut().add_pair(a, b, potential)
-                }
+        match try!(read_restriction(pair)) {
+            Some(restriction) => {
+                system.interactions_mut().add_pair_with_restriction(a, b, potential, restriction);
             },
-            TwoBody::Bonds => {
-                system.interactions_mut().add_bond(a, b, potential);
-            }
+            None => system.interactions_mut().add_pair(a, b, potential)
         }
+    }
+    Ok(())
+}
+
+/// Read the "bonds" section from the configuration.
+pub fn read_bonds(system: &mut System, bonds: &[Value]) -> Result<()> {
+    for bond in bonds {
+        let bond = try!(bond.as_table().ok_or(
+            Error::from("Bond potential entry must be a table")
+        ));
+
+        let atoms = extract_slice!("atoms", bond as "bond potential");
+        if atoms.len() != 2 {
+            return Err(Error::from(
+                format!("Wrong size for 'atoms' section in bond potential. Should be 2, is {}", atoms.len())
+            ));
+        }
+
+        let a = try!(atoms[0].as_str().ok_or(Error::from("The first atom name is not a string in pair potential")));
+        let b = try!(atoms[1].as_str().ok_or(Error::from("The second atom name is not a string in pair potential")));
+
+        let potential = try!(read_bond_potential(bond));
+        system.interactions_mut().add_bond(a, b, potential);
     }
     Ok(())
 }
@@ -79,6 +93,33 @@ fn read_pair_potential(pair: &Table) -> Result<Box<PairPotential>> {
             "null" => Ok(Box::new(try!(NullPotential::from_toml(table)))),
             "harmonic" => Ok(Box::new(try!(Harmonic::from_toml(table)))),
             "lj" | "lennardjones" => Ok(Box::new(try!(LennardJones::from_toml(table)))),
+            other => Err(
+                Error::from(format!("Unknown potential type '{}'", other))
+            ),
+        }
+    } else {
+        Err(
+            Error::from(format!("potential '{}' must be a table", key))
+        )
+    }
+}
+
+fn read_bond_potential(pair: &Table) -> Result<Box<BondPotential>> {
+    let potentials = pair.keys().cloned()
+                    .filter(|k| k != "atoms")
+                    .collect::<Vec<_>>();
+
+    if potentials.len() != 1 {
+        return Err(Error::from(
+            format!("Got more than one potential type: {}", potentials.join(" - "))
+        ));
+    }
+
+    let key = &*potentials[0];
+    if let Value::Table(ref table) = pair[key] {
+        match key {
+            "null" => Ok(Box::new(try!(NullPotential::from_toml(table)))),
+            "harmonic" => Ok(Box::new(try!(Harmonic::from_toml(table)))),
             other => Err(
                 Error::from(format!("Unknown potential type '{}'", other))
             ),

--- a/src/input/interactions/pairs.rs
+++ b/src/input/interactions/pairs.rs
@@ -9,7 +9,7 @@ use super::{FromTomlWithPairs, read_restriction};
 
 use potentials::{PairPotential, PairInteraction, BondPotential};
 use potentials::{Harmonic, LennardJones, NullPotential};
-use potentials::{TableComputation, CutoffComputation};
+use potentials::TableComputation;
 
 /// Read either the "pairs" section from the configuration.
 pub fn read_pairs(system: &mut System, pairs: &[Value]) -> Result<()> {
@@ -139,9 +139,6 @@ fn read_pair_computation(computation: &Table, potential: Box<PairPotential>) -> 
     }
 
     match computation.keys().map(|s| s.as_ref()).next() {
-        Some("cutoff") => Ok(
-            Box::new(try!(CutoffComputation::from_toml(computation, potential)))
-        ),
         Some("table") => Ok(
             Box::new(try!(TableComputation::from_toml(computation, potential)))
         ),
@@ -168,7 +165,7 @@ mod tests {
 
         read_interactions(&mut system, data_root.join("pairs.toml")).unwrap();
 
-        assert_eq!(system.pair_potentials(0, 1).len(), 10);
+        assert_eq!(system.pair_potentials(0, 1).len(), 9);
     }
 
     #[test]

--- a/src/input/interactions/toml.rs
+++ b/src/input/interactions/toml.rs
@@ -10,7 +10,7 @@ use super::FromTomlWithPairs;
 
 use potentials::{Harmonic, LennardJones, NullPotential, CosineHarmonic, Torsion};
 use potentials::{Wolf, Ewald};
-use potentials::{PairPotential, TableComputation, CutoffComputation};
+use potentials::{PairPotential, TableComputation};
 
 macro_rules! try_extract_parameter {
     ($table: expr, $key: expr, $context: expr) => (
@@ -100,20 +100,6 @@ impl FromToml for Torsion {
 }
 
 /******************************************************************************/
-
-impl FromTomlWithPairs for CutoffComputation {
-    fn from_toml(table: &Table, potential: Box<PairPotential>) -> Result<CutoffComputation> {
-        let cutoff = try_extract_parameter!(table, "cutoff", "cutoff computation");
-        if let Some(cutoff) = cutoff.as_str() {
-            let cutoff = try!(::units::from_str(cutoff));
-            Ok(CutoffComputation::new(potential, cutoff))
-        } else {
-            Err(
-                Error::from("'cutoff' must be a string in cutoff computation")
-            )
-        }
-    }
-}
 
 impl FromTomlWithPairs for TableComputation {
     fn from_toml(table: &Table, potential: Box<PairPotential>) -> Result<TableComputation> {

--- a/src/input/simulations/data/potentials.toml
+++ b/src/input/simulations/data/potentials.toml
@@ -8,6 +8,9 @@ guess_bonds = true
 velocities = {init = "300 K"}
 
 # inline potentials
+[systems.potentials.global]
+cutoff = "10 A"
+
 [[systems.potentials.pairs]]
 atoms = ["C", "O"]
 lj = {sigma = "3 A", epsilon = "5 kJ/mol"}

--- a/src/input/simulations/system.rs
+++ b/src/input/simulations/system.rs
@@ -161,7 +161,7 @@ mod tests {
         let last = system.size();
         system.add_particle(Particle::new("A"));
         system.add_particle(Particle::new("B"));
-        assert_eq!(system.pair_potentials(last, last + 1).len(), 9);
+        assert_eq!(system.pair_potentials(last, last + 1).len(), 10);
     }
 
     #[test]

--- a/src/input/simulations/system.rs
+++ b/src/input/simulations/system.rs
@@ -161,7 +161,7 @@ mod tests {
         let last = system.size();
         system.add_particle(Particle::new("A"));
         system.add_particle(Particle::new("B"));
-        assert_eq!(system.pair_potentials(last, last + 1).len(), 10);
+        assert_eq!(system.pair_potentials(last, last + 1).len(), 11);
     }
 
     #[test]

--- a/src/input/simulations/system.rs
+++ b/src/input/simulations/system.rs
@@ -161,7 +161,7 @@ mod tests {
         let last = system.size();
         system.add_particle(Particle::new("A"));
         system.add_particle(Particle::new("B"));
-        assert_eq!(system.pair_potentials(last, last + 1).len(), 10);
+        assert_eq!(system.pair_potentials(last, last + 1).len(), 9);
     }
 
     #[test]

--- a/src/potentials/computations.rs
+++ b/src/potentials/computations.rs
@@ -26,52 +26,6 @@ impl<P: Computation + Clone + 'static> Potential for P {
     }
 }
 
-/******************************************************************************/
-/// Computation of a potential with a cutoff.
-///
-/// Energy is shifted to ensure `E(rc) = 0`, where `rc` is the cutoff distance.
-#[derive(Clone)]
-pub struct CutoffComputation {
-    /// Potential to compute
-    potential: Box<PairPotential>,
-    /// Cutoff distance
-    cutoff: f64,
-    /// Energy at cutoff
-    delta: f64,
-}
-
-impl CutoffComputation {
-    /// Create a new `CutoffComputation` for `potential`, with cutoff distance
-    /// of `cutoff`.
-    pub fn new(potential: Box<PairPotential>, cutoff: f64) -> CutoffComputation {
-        let delta = potential.energy(cutoff);
-        CutoffComputation{potential: potential, cutoff: cutoff, delta: delta}
-    }
-}
-
-impl Computation for CutoffComputation {
-    #[inline]
-    fn compute_energy(&self, r: f64) -> f64 {
-        if r > self.cutoff {
-            return 0.0;
-        } else {
-            return self.potential.energy(r) - self.delta;
-        }
-    }
-
-    #[inline]
-    fn compute_force(&self, r: f64) -> f64 {
-        if r > self.cutoff {
-            return 0.0;
-        } else {
-            return self.potential.force(r);
-        }
-    }
-}
-
-impl PairPotential for CutoffComputation {}
-
-/******************************************************************************/
 /// Computation of a potential using tabulated values.
 ///
 /// This can be faster than direct computation for smooth potentials, but will
@@ -149,17 +103,6 @@ impl PairPotential for TableComputation {}
 mod test {
     use super::*;
     use potentials::Harmonic;
-
-    #[test]
-    fn cutoff() {
-        let cutoff = CutoffComputation::new(Box::new(Harmonic{k: 50.0, x0: 2.0}), 4.0);
-
-        assert_eq!(cutoff.compute_force(2.5), -25.0);
-        assert_eq!(cutoff.compute_energy(2.5), -93.75);
-
-        assert_eq!(cutoff.compute_force(4.1), 0.0);
-        assert_eq!(cutoff.compute_energy(4.1), 0.0);
-    }
 
     #[test]
     fn table() {

--- a/src/potentials/computations.rs
+++ b/src/potentials/computations.rs
@@ -1,12 +1,12 @@
 // Cymbalum, an extensible molecular simulation engine
 // Copyright (C) 2015-2016 G. Fraux — BSD license
 
-use super::{PotentialFunction, PairPotential};
+use super::{Potential, PairPotential};
 
 /// Methods for energy and forces computation.
 ///
 /// A potential computation is a way of computing a potential given its
-/// expression (represented by a `PotentialFunction`). The same potential can be
+/// expression (represented by a `Potential`). The same potential can be
 /// computed either direcly, or using a cutoff, or by a table interpolation, ...
 pub trait Computation: Sync + Send {
     /// Compute the energy value at `r`
@@ -16,7 +16,7 @@ pub trait Computation: Sync + Send {
     fn compute_force(&self, r: f64) -> f64;
 }
 
-impl<P: Computation + Clone + 'static> PotentialFunction for P {
+impl<P: Computation + Clone + 'static> Potential for P {
     #[inline] fn energy(&self, r:f64) -> f64 {
         self.compute_energy(r)
     }

--- a/src/potentials/functions.rs
+++ b/src/potentials/functions.rs
@@ -2,7 +2,7 @@
 // Copyright (C) 2015-2016 G. Fraux — BSD license
 
 use potentials::Potential;
-use potentials::{PairPotential, AnglePotential, DihedralPotential};
+use potentials::{PairPotential, BondPotential, AnglePotential, DihedralPotential};
 
 /// The `NullPotential` always returns 0 as energy and force.
 ///
@@ -16,6 +16,7 @@ impl Potential for NullPotential {
 }
 
 impl PairPotential for NullPotential {}
+impl BondPotential for NullPotential {}
 impl AnglePotential for NullPotential {}
 impl DihedralPotential for NullPotential {}
 
@@ -77,6 +78,7 @@ impl Potential for Harmonic {
 }
 
 impl PairPotential for Harmonic {}
+impl BondPotential for Harmonic {}
 impl AnglePotential for Harmonic {}
 impl DihedralPotential for Harmonic {}
 

--- a/src/potentials/mod.rs
+++ b/src/potentials/mod.rs
@@ -116,3 +116,5 @@ pub use self::restrictions::{PairRestriction, RestrictionInfo};
 mod global;
 pub use self::global::{GlobalPotential, CoulombicPotential};
 pub use self::global::{Wolf, Ewald};
+
+mod pairs;

--- a/src/potentials/mod.rs
+++ b/src/potentials/mod.rs
@@ -107,8 +107,7 @@ pub use self::functions::{NullPotential, LennardJones, Harmonic, CosineHarmonic}
 pub use self::functions::Torsion;
 
 mod computations;
-pub use self::computations::Computation;
-pub use self::computations::{TableComputation, CutoffComputation};
+pub use self::computations::{Computation, TableComputation};
 
 mod restrictions;
 pub use self::restrictions::{PairRestriction, RestrictionInfo};

--- a/src/potentials/mod.rs
+++ b/src/potentials/mod.rs
@@ -118,3 +118,4 @@ pub use self::global::{GlobalPotential, CoulombicPotential};
 pub use self::global::{Wolf, Ewald};
 
 mod pairs;
+pub use self::pairs::PairInteraction;

--- a/src/potentials/mod.rs
+++ b/src/potentials/mod.rs
@@ -71,9 +71,9 @@ pub trait Potential : Sync + Send + BoxClonePotential {
 
 impl_box_clone!(Potential, BoxClonePotential, box_clone_potential);
 
-/// Potential that can be used for two body interactions, either covalent or
-/// non-covalent.
-pub trait PairPotential : Potential + BoxClonePair {
+/// Computation of virial contribution for a potential. The provided fucntion
+/// only apply to two-body virial contributions.
+pub trait Virial: Potential {
     /// Compute the virial contribution corresponding to the distance `r`
     /// between the particles
     fn virial(&self, r: &Vector3D) -> Matrix3 {
@@ -84,7 +84,15 @@ pub trait PairPotential : Potential + BoxClonePair {
     }
 }
 
+impl<T: Potential> Virial for T {}
+
+/// Potential that can be used for non-bonded two body interactions
+pub trait PairPotential : Virial + BoxClonePair {}
 impl_box_clone!(PairPotential, BoxClonePair, box_clone_pair);
+
+/// Potential that can be used for molecular bonds
+pub trait BondPotential : Virial + BoxCloneBond {}
+impl_box_clone!(BondPotential, BoxCloneBond, box_clone_bond);
 
 /// Potential that can be used for molecular angles.
 pub trait AnglePotential : Potential + BoxCloneAngle {}

--- a/src/potentials/pairs.rs
+++ b/src/potentials/pairs.rs
@@ -1,0 +1,128 @@
+// Cymbalum, an extensible molecular simulation engine
+// Copyright (C) 2015-2016 G. Fraux — BSD license
+
+use potentials::{Potential, PairPotential, PairRestriction};
+
+/// The different way to compute non-bonded pair interactions
+#[derive(Clone, Copy, Debug)]
+enum PairComputation {
+    /// Using only a cutoff distance
+    Cutoff,
+    /// Using a cutoff distance and a shift
+    Shifted(f64),
+}
+
+/// A non-bonded interaction between two particle. The potential `T` is
+/// associated with a [pair restriction][PairRestriction]. For all non-bonded
+/// pairs, the potential is computed up to a cutoff distance. An additional
+/// shifting of the potential can be used in molecular dynamics, to ensure that
+/// the energy is continuous at the cutoff distance.
+///
+/// [PairRestriction]: enum.PairRestriction.html
+#[derive(Clone)]
+pub struct PairInteraction {
+    /// The potential of this interaction
+    potential: Box<PairPotential>,
+    /// The associated pair restrictions
+    restriction: PairRestriction,
+    /// The cutoff distance
+    cutoff: f64,
+    /// The computation mode
+    computation: PairComputation,
+}
+
+impl PairInteraction {
+    /// Create a new `PairInteraction` with the given cutoff
+    pub fn new(potential: Box<PairPotential>, cutoff: f64) -> PairInteraction {
+        PairInteraction {
+            potential: potential,
+            cutoff: cutoff,
+            restriction: PairRestriction::None,
+            computation: PairComputation::Cutoff,
+        }
+    }
+
+    /// Create a new `PairInteraction` with the given cutoff, using shifted
+    /// computation of the energy.
+    pub fn shifted(potential: Box<PairPotential>, cutoff: f64) -> PairInteraction {
+        let shift = potential.energy(cutoff);
+        PairInteraction {
+            potential: potential,
+            cutoff: cutoff,
+            restriction: PairRestriction::None,
+            computation: PairComputation::Shifted(shift),
+        }
+    }
+
+    /// Get the associated pair restriction
+    pub fn restriction(&self) -> PairRestriction {
+        self.restriction
+    }
+
+    /// Set the restriction associated with this potential
+    pub fn set_restriction(&mut self, restriction: PairRestriction) {
+        self.restriction = restriction;
+    }
+}
+
+impl Potential for PairInteraction {
+    fn energy(&self, r: f64) -> f64 {
+        if r >= self.cutoff {
+            0.0
+        } else {
+            let energy = self.potential.energy(r);
+            match self.computation {
+                PairComputation::Cutoff => energy,
+                PairComputation::Shifted(shift) => energy - shift,
+            }
+        }
+    }
+
+    fn force(&self, r: f64) -> f64 {
+        if r >= self.cutoff {
+            0.0
+        } else {
+            self.potential.force(r)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use potentials::{NullPotential, LennardJones, PairRestriction};
+    use potentials::Potential;
+
+    #[test]
+    fn restriction() {
+        let mut pairs = PairInteraction::new(Box::new(NullPotential), 10.0);
+        assert_eq!(pairs.restriction(), PairRestriction::None);
+
+        pairs.set_restriction(PairRestriction::Exclude13);
+        assert_eq!(pairs.restriction(), PairRestriction::Exclude13);
+    }
+
+    #[test]
+    fn cutoff() {
+        let lj = LennardJones{sigma: 1.0, epsilon: 2.0};
+        let pairs = PairInteraction::new(Box::new(lj), 4.0);
+
+        assert_eq!(pairs.force(2.5), lj.force(2.5));
+        assert_eq!(pairs.energy(2.5), lj.energy(2.5));
+
+        assert_eq!(pairs.force(4.1), 0.0);
+        assert_eq!(pairs.energy(4.1), 0.0);
+    }
+
+    #[test]
+    fn shifted() {
+        let lj = LennardJones{sigma: 1.0, epsilon: 2.0};
+        let pairs = PairInteraction::shifted(Box::new(lj), 4.0);
+
+        assert_eq!(pairs.force(2.5), lj.force(2.5));
+        assert_approx_eq!(pairs.energy(2.5), -0.030681134109158216);
+
+        assert_eq!(pairs.force(4.1), 0.0);
+        assert_eq!(pairs.energy(4.1), 0.0);
+    }
+}

--- a/src/potentials/restrictions.rs
+++ b/src/potentials/restrictions.rs
@@ -13,7 +13,7 @@ use system::System;
 ///
 /// Some pairs can be excluded from the energy computation; this enum lists the
 /// possible case of exclusion.
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum PairRestriction {
     /// No pair should be excluded
     None,

--- a/src/simulation/minimization/steepest_descent.rs
+++ b/src/simulation/minimization/steepest_descent.rs
@@ -122,7 +122,10 @@ mod tests {
         system[0].position = Vector3D::zero();
         system.add_particle(Particle::new("Cl"));
         system[1].position = Vector3D::new(0.0, 0.0, 2.0);
-        system.interactions_mut().add_pair("Cl", "Cl", Box::new(Harmonic{x0: 2.3, k: 0.1}));
+
+        system.interactions_mut().add_pair("Cl", "Cl",
+            PairInteraction::new(Box::new(Harmonic{x0: 2.3, k: 0.1}), 10.0)
+        );
 
         let mut minization = SteepestDescent::new();
         for _ in 0..100 {

--- a/src/simulation/outputs.rs
+++ b/src/simulation/outputs.rs
@@ -203,8 +203,13 @@ mod tests {
         system.add_particle(Particle::new("F"));
         system[1].position = Vector3D::new(1.3, 0.0, 0.0);
 
+        let harmonic = Box::new(Harmonic{
+            k: unit_from(300.0, "kJ/mol/A^2"),
+            x0: unit_from(1.2, "A")}
+        );
         system.interactions_mut().add_pair("F", "F",
-            Box::new(Harmonic{k: unit_from(300.0, "kJ/mol/A^2"), x0: unit_from(1.2, "A")}));
+            PairInteraction::new(harmonic, 5.0)
+        );
         return system;
     }
 

--- a/src/system/cache.rs
+++ b/src/system/cache.rs
@@ -292,6 +292,9 @@ mod tests {
         [input]
         version = 1
 
+        [global]
+        cutoff = "3 A"
+
         # Values are completely random, just having a bit of all the types
         [[pairs]]
         atoms = ["H", "H"]

--- a/src/system/interactions.rs
+++ b/src/system/interactions.rs
@@ -8,7 +8,7 @@ use std::collections::BTreeMap;
 use std::cmp::max;
 use std::cell::RefCell;
 
-use potentials::{PairPotential, AnglePotential, DihedralPotential};
+use potentials::{PairPotential, BondPotential, AnglePotential, DihedralPotential};
 use potentials::{GlobalPotential, CoulombicPotential};
 use potentials::PairRestriction;
 
@@ -76,7 +76,7 @@ pub struct Interactions {
     /// Pair potentials
     pairs: BTreeMap<(Kind, Kind), Vec<PairInteraction>>,
     /// Bond potentials
-    bonds: BTreeMap<(Kind, Kind), Vec<Box<PairPotential>>>,
+    bonds: BTreeMap<(Kind, Kind), Vec<Box<BondPotential>>>,
     /// Angle potentials
     angles: BTreeMap<(Kind, Kind, Kind), Vec<Box<AnglePotential>>>,
     /// Dihedral angles potentials
@@ -127,7 +127,7 @@ impl Interactions {
     }
 
     /// Add the `potential` bonded interaction for the pair `(i, j)`
-    pub fn add_bond(&mut self, i: &str, j: &str, potential: Box<PairPotential>) {
+    pub fn add_bond(&mut self, i: &str, j: &str, potential: Box<BondPotential>) {
         let (i, j) = (self.get_kind(i), self.get_kind(j));
         let (i, j) = sort_pair(i, j);
         let bonds = self.bonds.entry((i, j)).or_insert(Vec::new());
@@ -163,7 +163,7 @@ impl Interactions {
 }
 
 static NO_PAIR_INTERACTION: &'static [PairInteraction] = &[];
-static NO_BOND_INTERACTION: &'static [Box<PairPotential>] = &[];
+static NO_BOND_INTERACTION: &'static [Box<BondPotential>] = &[];
 static NO_ANGLE_INTERACTION: &'static [Box<AnglePotential>] = &[];
 static NO_DIHEDRAL_INTERACTION: &'static [Box<DihedralPotential>] = &[];
 
@@ -184,7 +184,7 @@ impl Interactions {
     }
 
     /// Get all bonded interactions corresponding to the pair `(i, j)`
-    pub fn bonds(&self, i: Kind, j: Kind) -> &[Box<PairPotential>] {
+    pub fn bonds(&self, i: Kind, j: Kind) -> &[Box<BondPotential>] {
         let (i, j) = sort_pair(i, j);
         if let Some(val) = self.bonds.get(&(i, j)) {
             val

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -40,9 +40,3 @@ pub use self::systems::Permutations;
 
 pub mod compute;
 pub use self::compute::Compute;
-pub use self::compute::Forces;
-pub use self::compute::{PotentialEnergy, KineticEnergy, TotalEnergy};
-pub use self::compute::Temperature;
-pub use self::compute::Volume;
-pub use self::compute::{Virial, Stress, Pressure};
-pub use self::compute::{StressAtTemperature, PressureAtTemperature};

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -26,7 +26,6 @@ pub use self::molecules::Molecule;
 pub use self::molecules::moltype;
 
 mod interactions;
-pub use self::interactions::PairInteraction;
 
 mod energy;
 pub use self::energy::EnergyEvaluator;

--- a/src/system/systems.rs
+++ b/src/system/systems.rs
@@ -12,6 +12,7 @@ use std::cmp::{min, max};
 use std::iter::IntoIterator;
 use std::i8;
 
+use potentials::PairInteraction;
 use potentials::{BondPotential, AnglePotential, DihedralPotential};
 use types::{Vector3D, Matrix3};
 
@@ -19,7 +20,7 @@ use super::{Particle, ParticleKind};
 use super::Molecule;
 use super::{CONNECT_12, CONNECT_13, CONNECT_14, CONNECT_FAR};
 use super::UnitCell;
-use super::interactions::{Interactions, PairInteraction};
+use super::interactions::Interactions;
 use super::EnergyEvaluator;
 use super::molecules::moltype;
 

--- a/src/system/systems.rs
+++ b/src/system/systems.rs
@@ -12,7 +12,7 @@ use std::cmp::{min, max};
 use std::iter::IntoIterator;
 use std::i8;
 
-use potentials::{PairPotential, AnglePotential, DihedralPotential};
+use potentials::{BondPotential, AnglePotential, DihedralPotential};
 use types::{Vector3D, Matrix3};
 
 use super::{Particle, ParticleKind};
@@ -393,7 +393,7 @@ impl System {
 
     /// Get the list of bonded potential acting between the particles at indexes
     /// `i` and `j`.
-    pub fn bond_potentials(&self, i: usize, j: usize) -> &[Box<PairPotential>] {
+    pub fn bond_potentials(&self, i: usize, j: usize) -> &[Box<BondPotential>] {
         let ikind = self.particles[i].kind;
         let jkind = self.particles[j].kind;
         self.interactions.bonds(ikind, jkind)
@@ -500,12 +500,12 @@ impl System {
 
 /******************************************************************************/
 use system::Compute;
-use system::{PotentialEnergy, KineticEnergy, TotalEnergy};
-use system::Forces;
-use system::Temperature;
-use system::Volume;
-use system::{Virial, Stress, Pressure};
-use system::{StressAtTemperature, PressureAtTemperature};
+use system::compute::{PotentialEnergy, KineticEnergy, TotalEnergy};
+use system::compute::Forces;
+use system::compute::Temperature;
+use system::compute::Volume;
+use system::compute::{Virial, Stress, Pressure};
+use system::compute::{StressAtTemperature, PressureAtTemperature};
 
 /// Functions to get pysical properties of a system.
 impl System {

--- a/tests/data/NaCl-ewald.toml
+++ b/tests/data/NaCl-ewald.toml
@@ -1,6 +1,9 @@
 [input]
 version = 1
 
+[global]
+cutoff = "11 A"
+
 [[pairs]]
 atoms = ["Na", "Cl"]
 lj = {sigma = "3.5545 A", epsilon = "0.04425 kcal/mol"}

--- a/tests/data/NaCl-wolf.toml
+++ b/tests/data/NaCl-wolf.toml
@@ -1,6 +1,9 @@
 [input]
 version = 1
 
+[global]
+cutoff = "11 A"
+
 [[pairs]]
 atoms = ["Na", "Cl"]
 lj = {sigma = "3.5545 A", epsilon = "0.04425 kcal/mol"}

--- a/tests/data/butane.toml
+++ b/tests/data/butane.toml
@@ -3,6 +3,7 @@ version = 1
 
 [[pairs]]
 atoms = ["C", "C"]
+cutoff = {shifted = "10 A"}
 lj = {sigma = "3.4 A", epsilon = "0.7 kcal/mol"}
 restriction = "InterMolecular"
 

--- a/tests/data/methane.toml
+++ b/tests/data/methane.toml
@@ -1,6 +1,9 @@
 [input]
 version = 1
 
+[global]
+cutoff = {shifted = "10 A"}
+
 [[pairs]]
 atoms = ["C", "C"]
 lj = {sigma = "3.7 A", epsilon = "0.2981 kcal/mol"}

--- a/tests/data/water-ewald.toml
+++ b/tests/data/water-ewald.toml
@@ -1,6 +1,9 @@
 [input]
 version = 1
 
+[global]
+cutoff = "14 A"
+
 # f-SPC model of water, using ewald summation for electrostatics
 [[pairs]]
 atoms = ["O", "O"]

--- a/tests/data/water-wolf.toml
+++ b/tests/data/water-wolf.toml
@@ -1,6 +1,9 @@
 [input]
 version = 1
 
+[global]
+cutoff = "14 A"
+
 # f-SPC model of water, using ewald summation for electrostatics
 [[pairs]]
 atoms = ["O", "O"]

--- a/tests/mc-helium.rs
+++ b/tests/mc-helium.rs
@@ -19,12 +19,11 @@ fn get_system() -> System {
                                         .unwrap();
     system.set_cell(UnitCell::cubic(10.0));
 
-    system.interactions_mut().add_pair("He", "He",
-        Box::new(LennardJones{
-            sigma: units::from(2.0, "A").unwrap(),
-            epsilon: units::from(0.2, "kJ/mol").unwrap()
-        })
-    );
+    let lj = Box::new(LennardJones{
+        sigma: units::from(2.0, "A").unwrap(),
+        epsilon: units::from(0.2, "kJ/mol").unwrap()
+    });
+    system.interactions_mut().add_pair("He", "He", PairInteraction::new(lj, 5.0));
     return system;
 }
 


### PR DESCRIPTION
This is preliminary work for #28, and not finished yet. Are missing:

- [x] A way to provide the cutoff value and the shifted/not-shifted behaviour in the input;
- [x] Documentation;
- [x] More integration tests;

I am opening this to get a feedback on the API. @g-bauer, this will allow to add tail corrections by:

1. adding a `Tail` variant to [PairComputation](https://github.com/Luthaf/cymbalum/blob/e5fd14ab1e7d6795e3c9251072bd9121046abb6b/src/potentials/pairs.rs#L8); 
2. adding the `tail_energy` and `tail_virial` methods to `PairPotential`

An unresolved question is what to do with the `TableComputation`. This make `CutoffComputation` useless, and we may want to unify the TableComputation in the `PairComputation` enum. But we may also want to use table interpolations for other bonded interactions (bond, angles, ...)